### PR TITLE
Use partition-based stats for spinning down disks

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ the disks to monitor. An example may look like this:
     
     CONF_INT=300
     
-    CONF_DEV=( "ata-WDC_WD50EFRX-68MYMN1_WD-WX31DA43KKCY|5400|sda1|sda2|sda3" \
+    CONF_DEV=( "ata-WDC_WD50EFRX-68MYMN1_WD-WX31DA43KKCY|5400|sda1|12345678-abcd-f00d-1234-1234567890ab|sda3" \
                "ata-WDC_WD50EFRX-68MYMN1_WD-WX81DA4HNEH5|5400|bcache1" \
                "ata-WDC_WD20EARS-00MVWB0_WD-WCAZA5755786|5400|sdc3" \
                "ata-WDC_WD20EARS-00MVWB0_WD-WMAZA3570471|5400" )
@@ -53,7 +53,8 @@ default interval of 5 minutes.
 
 Newer kernels (>5.4) need the partitions of the device listed separately,
 since only checking the disk stats will prevent spindown. Partitions have
-to be separated by the pipe symbol '|'.
+to be separated by the pipe symbol '|'. UUIDs can be used to specify
+partitions.
 
 For a complete list of options please see the example `hdd-spindown.rc`.
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Note that devices may be specified using their ID (as shown) or device
 name (e.g. 'sda'). The interval option may be omitted, which sets the
 default interval of 5 minutes.
 
-Newer kernels (>5.5) need the partitions of the device listed separately,
+Newer kernels (>5.4) need the partitions of the device listed separately,
 since only checking the disk stats will prevent spindown. Partitions have
 to be separated by the pipe symbol '|'.
 

--- a/README.md
+++ b/README.md
@@ -38,9 +38,9 @@ the disks to monitor. An example may look like this:
     
     CONF_INT=300
     
-    CONF_DEV=( "ata-WDC_WD50EFRX-68MYMN1_WD-WX31DA43KKCY|5400" \
-               "ata-WDC_WD50EFRX-68MYMN1_WD-WX81DA4HNEH5|5400" \
-               "ata-WDC_WD20EARS-00MVWB0_WD-WCAZA5755786|5400" \
+    CONF_DEV=( "ata-WDC_WD50EFRX-68MYMN1_WD-WX31DA43KKCY|5400|sda1|sda2|sda3" \
+               "ata-WDC_WD50EFRX-68MYMN1_WD-WX81DA4HNEH5|5400|bcache1" \
+               "ata-WDC_WD20EARS-00MVWB0_WD-WCAZA5755786|5400|sdc3" \
                "ata-WDC_WD20EARS-00MVWB0_WD-WMAZA3570471|5400" )
   
 `CONF_INT` specifies the monitoring interval in seconds while `CONF_DEV`
@@ -50,6 +50,10 @@ seconds, separated by the pipe symbol '|'.
 Note that devices may be specified using their ID (as shown) or device
 name (e.g. 'sda'). The interval option may be omitted, which sets the
 default interval of 5 minutes.
+
+Newer kernels (>5.5) need the partitions of the device listed separately,
+since only checking the disk stats will prevent spindown. Partitions have
+to be separated by the pipe symbol '|'.
 
 For a complete list of options please see the example `hdd-spindown.rc`.
 

--- a/hdd-spindown.rc
+++ b/hdd-spindown.rc
@@ -1,10 +1,10 @@
 # Configuration file for 'hdd-spindown.sh'
 
 # Devices to be monitored
-# 	Node names (e.g. 'sda') or ATA-IDs, timeout in seconds
+#	Node names (e.g. 'sda') or ATA-IDs, timeout in seconds, partitions on device (optional, needed for kernels > 5.5)
 #
-#CONF_DEV=( 'sda|3600' \
-#			'sdb|3600' ) 
+#CONF_DEV=( 'sda|3600|sda1|sda2' \
+#			'sdb|3600|bcache1' ) 
 
 # Hosts to monitor for 'presence' feature
 #CONF_HOSTS=( )

--- a/hdd-spindown.rc
+++ b/hdd-spindown.rc
@@ -1,7 +1,7 @@
 # Configuration file for 'hdd-spindown.sh'
 
 # Devices to be monitored
-#	Node names (e.g. 'sda') or ATA-IDs, timeout in seconds, partitions on device (optional, needed for kernels > 5.5)
+#	Node names (e.g. 'sda') or ATA-IDs, timeout in seconds, partitions on device (optional, needed for kernels > 5.4)
 #
 #CONF_DEV=( 'sda|3600|sda1|sda2' \
 #			'sdb|3600|bcache1' ) 

--- a/hdd-spindown.sh
+++ b/hdd-spindown.sh
@@ -35,11 +35,6 @@ function selftest_active() {
 	return $?
 }
 
-function dev_stats() {
-	read R_IO R_M R_S R_T W_IO REST < "/sys/block/$1/stat"
-	echo "$R_IO $W_IO"
-}
-
 function all_stats() {
 	ALL_STATS=()
 	while read MAJ MIN DEV R_IO R_M R_S R_T W_IO REST ; do


### PR DESCRIPTION
On newer kernels (apparently >5.4) disk monitoring tools will alter R/W stats in `/sys/block/$1/stat`, therefore preventing hdd-spindown.sh from ever spinning down disks. Individual partitions listed in `/proc/diskstats` however will stay unchanged if no "real" activity happened.

These commits will change hdd-spindown.sh to read `/proc/diskstats` once per interval and store the individual disks and partitions in an array. Comparing disks will now optionally loop over their corresponding partitions if defined in `hdd-spindown.rc`. If R/W stats of _all_ partitions did not change, hdd-spindown.sh will be instructed to spin down the disk, ignoring any change in activity on disk level.

Ideally this should solve #5 :)