### PR TITLE
Recognize IDLE drives in dev_isup

### DIFF
--- a/hdd-spindown.sh
+++ b/hdd-spindown.sh
@@ -41,7 +41,7 @@ function dev_stats() {
 }
 
 function dev_isup() {
-	$SMARTCTL -i -n standby "/dev/$1" | grep -q ACTIVE
+	$SMARTCTL -i -n standby "/dev/$1" | grep -q -e ACTIVE -e IDLE
 	return $?
 }
 


### PR DESCRIPTION
It turns out that compared to WD Red (which say `ACTIVE or IDLE`), these Seagate IronWolf Pro drives instead say `IDLE_2`, so this allows these drives to be suspended.